### PR TITLE
Issue #144: Display reminder to include saved nodes in frontpage slider

### DIFF
--- a/drupal8/config/sync/core.extension.yml
+++ b/drupal8/config/sync/core.extension.yml
@@ -16,6 +16,7 @@ module:
   breakpoint: 0
   cbc_search: 0
   cbc_searchable_actions: 0
+  cbc_slider: 0
   cbc_status_bar: 0
   cbc_token: 0
   cbc_updates: 0

--- a/drupal8/web/modules/custom/cbc_slider/cbc_slider.info.yml
+++ b/drupal8/web/modules/custom/cbc_slider/cbc_slider.info.yml
@@ -1,0 +1,6 @@
+name: CBC Slider
+type: module
+description: Add new content to the frontpage slider
+core: 8.x
+package: Custom
+dependencies:

--- a/drupal8/web/modules/custom/cbc_slider/cbc_slider.module
+++ b/drupal8/web/modules/custom/cbc_slider/cbc_slider.module
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Add new content to the frontpage slider.
+ */
+
+use Drupal\node\Entity\Node;
+
+/**
+ * Implements hook_ENTITY_TYPE_insert().
+ */
+function cbc_slider_node_insert(Node $node) {
+  drupal_set_message(t("Don't forget to add this content to the frontpage slider if needed."), 'warning');
+}


### PR DESCRIPTION
When a node is saved, a reminder is displayed for the editor to include it in the frontpage slider if needed (see screenshot). Instead of custom code I used the Rules module because it allows us to create reactions to events in an easy and flexible way that might come in handy in the future too.
![FireShot Capture 126 - test - CBCNY - localhost](https://user-images.githubusercontent.com/397530/54626250-cc729580-4a3e-11e9-95b3-3294e1226bf9.png)

